### PR TITLE
Fix coalesce crash when sqs_autoscaling is disabled

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -28,11 +28,13 @@ locals {
   # SQS Autoscaling queue name resolution
   sqs_out_queue = coalesce(
     try(var.sqs_autoscaling.scale_out_queue_name, null),
-    try(var.sqs_autoscaling.queue_name, null)
+    try(var.sqs_autoscaling.queue_name, null),
+    ""
   )
   sqs_in_queue = coalesce(
     try(var.sqs_autoscaling.scale_in_queue_name, null),
-    try(var.sqs_autoscaling.queue_name, null)
+    try(var.sqs_autoscaling.queue_name, null),
+    ""
   )
 
   # SQS Autoscaling defaults (hardcoded module best practices)


### PR DESCRIPTION
## Summary
- Adds empty string fallback to `sqs_out_queue` and `sqs_in_queue` `coalesce()` calls in `locals.tf`
- Fixes `terraform plan` crash when `sqs_autoscaling` is not configured (all queue name fields default to null)
- Safe because these locals are only referenced in resources gated by `var.sqs_autoscaling.enabled`

Follows up on #24 which fixed a similar null-value crash in validations.