### PR TITLE
Fix coalesce crash: replace with null-check ternaries

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -26,16 +26,8 @@ locals {
   }
 
   # SQS Autoscaling queue name resolution
-  sqs_out_queue = coalesce(
-    try(var.sqs_autoscaling.scale_out_queue_name, null),
-    try(var.sqs_autoscaling.queue_name, null),
-    ""
-  )
-  sqs_in_queue = coalesce(
-    try(var.sqs_autoscaling.scale_in_queue_name, null),
-    try(var.sqs_autoscaling.queue_name, null),
-    ""
-  )
+  sqs_out_queue = var.sqs_autoscaling.scale_out_queue_name != null ? var.sqs_autoscaling.scale_out_queue_name : (var.sqs_autoscaling.queue_name != null ? var.sqs_autoscaling.queue_name : "unused")
+  sqs_in_queue  = var.sqs_autoscaling.scale_in_queue_name != null ? var.sqs_autoscaling.scale_in_queue_name : (var.sqs_autoscaling.queue_name != null ? var.sqs_autoscaling.queue_name : "unused")
 
   # SQS Autoscaling defaults (hardcoded module best practices)
   sqs_require_empty_for_scale_in = coalesce(try(var.sqs_autoscaling.require_empty_for_scale_in, null), false)


### PR DESCRIPTION
## Summary
- Fixes the crash from #25 where `coalesce(..., "")` still fails because `coalesce()` rejects empty strings too
- Replaces `coalesce()` with explicit `!= null` ternary checks for `sqs_out_queue` and `sqs_in_queue`
- Uses `"unused"` as the fallback value, which is safe since all consumers are gated by `var.sqs_autoscaling.enabled`