### PR TITLE
Remove SSM tags parameter and use ECS service tag propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,10 +191,13 @@ pipeline can read it without reconstructing values:
 | Parameter | Value | Notes |
 |---|---|---|
 | `/ecs/<cluster>/<service>/role` | Effective task/execution role ARN | Not created when no role exists (`role.create = false` and `initial_role` empty). |
-| `/ecs/<cluster>/<service>/tags` | Effective tags as JSON (`{ Application } + var.tags`) | Always created. |
 
-The parameter names are exposed via the `ssm_role_parameter_name` and
-`ssm_tags_parameter_name` outputs.
+The parameter name is exposed via the `ssm_role_parameter_name` output.
+
+Tags are **not** published to SSM. Tasks are tagged by tagging the ECS service
+(`{ Application } + var.tags`) together with `propagate_tags = "SERVICE"`, so
+tasks inherit the service tags directly — the deploy pipeline does not need to
+read tags from SSM.
 
 ## DNS Configuration
 
@@ -413,7 +416,6 @@ This module is released under the MIT License.
 | [aws_route53_record.additional_alb_records](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.main_alb_record](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_ssm_parameter.role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
-| [aws_ssm_parameter.tags](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_ecs_cluster.ecs_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecs_cluster) | data source |
 | [aws_lb.additional_albs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb) | data source |
@@ -471,5 +473,4 @@ This module is released under the MIT License.
 | <a name="output_service_role_arn"></a> [service\_role\_arn](#output\_service\_role\_arn) | ARN of the IAM role created for this service (null if role.create = false). |
 | <a name="output_service_role_name"></a> [service\_role\_name](#output\_service\_role\_name) | Name of the IAM role created for this service (null if role.create = false). |
 | <a name="output_ssm_role_parameter_name"></a> [ssm\_role\_parameter\_name](#output\_ssm\_role\_parameter\_name) | Name of the SSM parameter holding the service role ARN (null when no role exists). |
-| <a name="output_ssm_tags_parameter_name"></a> [ssm\_tags\_parameter\_name](#output\_ssm\_tags\_parameter\_name) | Name of the SSM parameter holding the service tags (JSON). |
 <!-- END_TF_DOCS -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -24,11 +24,6 @@ output "ssm_role_parameter_name" {
   value       = length(aws_ssm_parameter.role) > 0 ? aws_ssm_parameter.role[0].name : null
 }
 
-output "ssm_tags_parameter_name" {
-  description = "Name of the SSM parameter holding the service tags (JSON)."
-  value       = aws_ssm_parameter.tags.name
-}
-
 output "route53_records" {
   description = "Route53 DNS records created"
   value = {

--- a/ssm.tf
+++ b/ssm.tf
@@ -3,7 +3,12 @@
 #########################
 # Publish per-service metadata to SSM Parameter Store at predictable paths so the
 # deploy pipeline can read them (e.g. to attach the role to the real, CI-managed
-# task definition and to apply the service tags).
+# task definition).
+#
+# Note: tags are intentionally NOT published here. Task tagging is handled by
+# tagging the ECS service (see aws_ecs_service.tags) together with
+# propagate_tags = "SERVICE", so tasks inherit the service tags directly and the
+# pipeline does not need to read tags from SSM.
 
 # /ecs/<cluster>/<service>/role — the task/execution role ARN.
 # Skipped when no role is available (role.create = false AND initial_role = "").
@@ -13,13 +18,5 @@ resource "aws_ssm_parameter" "role" {
   name  = "/ecs/${var.ecs_cluster_name}/${var.ecs_service_name}/role"
   type  = "String"
   value = local.service_role_arn
-  tags  = local.common_tags
-}
-
-# /ecs/<cluster>/<service>/tags — the effective tags ({ Application } merged with var.tags), JSON-encoded.
-resource "aws_ssm_parameter" "tags" {
-  name  = "/ecs/${var.ecs_cluster_name}/${var.ecs_service_name}/tags"
-  type  = "String"
-  value = jsonencode(local.common_tags)
   tags  = local.common_tags
 }


### PR DESCRIPTION
## Summary
This change removes the SSM Parameter Store tags parameter and simplifies tag management by leveraging ECS native tag propagation instead. Tags are now applied directly to the ECS service with `propagate_tags = "SERVICE"`, allowing tasks to inherit tags automatically without requiring the deploy pipeline to read them from SSM.

## Key Changes
- **Removed `aws_ssm_parameter.tags` resource** from `ssm.tf` that was publishing effective tags as JSON to SSM Parameter Store
- **Removed `ssm_tags_parameter_name` output** from `outputs.tf` since the parameter no longer exists
- **Updated documentation** in `ssm.tf` comments and `README.md` to explain the new tagging approach:
  - Clarified that tags are intentionally NOT published to SSM
  - Documented that task tagging is handled via ECS service tag propagation
  - Updated the SSM parameters table to remove the tags parameter entry
  - Updated output documentation to reference only `ssm_role_parameter_name`

## Implementation Details
- Tags continue to be computed as `{ Application } + var.tags` (stored in `local.common_tags`)
- Instead of publishing to SSM, these tags are applied to the `aws_ecs_service` resource
- The `propagate_tags = "SERVICE"` setting ensures ECS tasks automatically inherit the service tags
- This eliminates the need for the deploy pipeline to reconstruct or read tags from SSM, simplifying the deployment process

https://claude.ai/code/session_01HLwFHwd41TjSw5RE8kwmzY