### PR TITLE
ci: validate terraform on PRs; pin terraform-docs action to a SHA

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -1,7 +1,9 @@
 name: Generate terraform docs
 on:
-  - pull_request
-  - push
+  pull_request:
+  push:
+    branches:
+      - main
 
 permissions:
   contents: write
@@ -14,7 +16,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Render terraform docs and push changes back to PR
-        uses: terraform-docs/gh-actions@main
+        uses: terraform-docs/gh-actions@6de6da0cefcc6b4b7a5cbea4d79d97060733093c # v1.4.1
         with:
           working-dir: .
           output-file: README.md

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,0 +1,41 @@
+name: Terraform validate
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.9.8
+          terraform_wrapper: false
+
+      - name: terraform fmt
+        run: terraform fmt -check -recursive
+
+      - name: Validate module
+        run: |
+          terraform init -backend=false -input=false
+          terraform validate
+
+      - name: Validate examples
+        working-directory: examples
+        run: |
+          terraform init -backend=false -input=false
+          terraform validate
+
+      - name: Validate examples/gpu
+        working-directory: examples/gpu
+        run: |
+          terraform init -backend=false -input=false
+          terraform validate


### PR DESCRIPTION
Second of a series splitting #33 into small, reviewable PRs. Follows #34, which made the example roots valid so this workflow can pass.

## 1. Nothing enforces `fmt` or `validate`

The repo has two workflows — docs rendering and version tagging — and neither checks that the Terraform actually parses. `CONTRIBUTING.md` documents the commands, but nothing runs them, which is how #34's four validation failures survived (one of them since de946b6).

Adds `.github/workflows/validate.yaml`, running on PRs and pushes to `main`:

- `terraform fmt -check -recursive` across the repo
- `terraform validate` in each of the three independent roots: the module, `examples/`, and `examples/gpu/`

`permissions: contents: read` — this workflow needs no write access.

## 2. `terraform-docs/gh-actions` is pinned to a moving branch

```yaml
uses: terraform-docs/gh-actions@main   # before
permissions: { contents: write }
git-push: "true"
```

The action is referenced by branch, runs with `contents: write`, and pushes commits back to this repository. Anyone who can move that upstream branch can push arbitrary commits here. This is the standard supply-chain hazard that SHA pinning exists to close.

Pinned to `6de6da0cefcc6b4b7a5cbea4d79d97060733093c` (v1.4.1, current latest). The trailing `# v1.4.1` comment is load-bearing — Renovate reads it to know what the SHA points at, so the pin stays maintainable rather than frozen.

## 3. The docs workflow runs twice per push

`on: [pull_request, push]` fires both triggers for every push to a branch with an open PR, rendering docs twice. Narrowed to `pull_request` plus `push` to `main` only.

## Verification

The workflow's exact commands, run locally against this branch:

```
terraform fmt -check -recursive   PASS
terraform validate  (module)      PASS
terraform validate  (examples)    PASS
terraform validate  (examples/gpu) PASS
```

## Risk

None to consumers. `.github/**` only — no module code changes, and `git-tag.yaml`'s `paths-ignore` means merging this cuts no release.

The one thing to know: once merged, a PR that fails `fmt` or `validate` is blocked rather than merged silently. That is the point, but it will be enforced on every PR that follows.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NvfKKjdfjNzSBTidn9Q9)_