### PR TITLE
fix: derive SSM role parameter count from config, not the resolved ARN

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -9,6 +9,12 @@ locals {
   # role.create = true, otherwise fall back to initial_role (or null).
   service_role_arn = var.role.create ? aws_iam_role.this[0].arn : (var.initial_role != "" ? var.initial_role : null)
 
+  # Derived from configuration rather than from service_role_arn, because
+  # aws_iam_role.this[0].arn is unknown at plan time until the role exists, and
+  # a count derived from an unknown value fails the plan. Anything using this as
+  # a count or for_each must not switch to testing the ARN.
+  has_service_role = var.role.create || var.initial_role != ""
+
   # Validation: Fargate requires awsvpc network mode
   validate_fargate_network_mode = (
     var.ecs_launch_type != "FARGATE" || var.network_mode == "awsvpc"

--- a/ssm.tf
+++ b/ssm.tf
@@ -13,7 +13,7 @@
 # /ecs/<cluster>/<service>/role — the task/execution role ARN.
 # Skipped when no role is available (role.create = false AND initial_role = "").
 resource "aws_ssm_parameter" "role" {
-  count = local.service_role_arn != null ? 1 : 0
+  count = local.has_service_role ? 1 : 0
 
   name  = "/ecs/${var.ecs_cluster_name}/${var.ecs_service_name}/role"
   type  = "String"


### PR DESCRIPTION
Third of a series splitting #33 into small PRs. Follows #34 and #35. This is the first one that changes module code, and it fixes a bug present in released **v1.1.1**.

## Problem

`role.create = true` cannot complete a first apply.

`aws_ssm_parameter.role` derives its `count` from the resolved role ARN:

```hcl
# locals.tf
service_role_arn = var.role.create ? aws_iam_role.this[0].arn : (var.initial_role != "" ? var.initial_role : null)

# ssm.tf
count = local.service_role_arn != null ? 1 : 0
```

When `role.create = true` and the role is not yet in state, `aws_iam_role.this[0].arn` is unknown at plan time. `unknown != null` is itself unknown, so the `count` is unknown and Terraform refuses to plan:

```
Error: Invalid count argument

  on ssm.tf line 16, in resource "aws_ssm_parameter" "role":
  16:   count = local.service_role_arn != null ? 1 : 0

The "count" value depends on resource attributes that cannot be determined
until apply, so Terraform cannot predict how many instances will be created.
```

There is no way through this from a clean state — the plan fails, so the role is never created, so the ARN stays unknown. Anyone adopting `role.create` (added in #31) hits it on their first apply.

### Why it isn't caught everywhere

This depends on the provider's SDK generation. Plugin-framework and built-in providers attach a *not-null refinement* to unknown values, which lets `!= null` collapse to a known `true`. `aws_iam_role` is SDKv2-based and returns **unrefined** unknowns, so the comparison stays unknown. A reproduction using `terraform_data` plans fine; the same reproduction against a legacy SDKv2 provider fails. Worth knowing because it means the pattern is unsafe against any SDKv2 resource regardless of how it behaves in a given test.

## Fix

Derive the count from configuration, which is always known at plan time:

```hcl
has_service_role = var.role.create || var.initial_role != ""
```

The truth table is unchanged:

| Configuration | Before | After |
|---|---|---|
| `role.create = true` | *plan fails* | parameter created |
| `initial_role != ""` | created | created |
| neither | skipped | skipped |

I audited every `count` and `for_each` in the module — this was the only one depending on a resource attribute. Everything else already derives from `var.*`, so this is the complete blast radius.

## Verification

Reproduced against `null_resource` (legacy SDKv2, same unknown-refinement behaviour as `aws_iam_role`):

```
OLD guard, role.create = true          Error: Invalid count argument
NEW guard, role.create = true          Plan: 2 to add
NEW guard, create=false + initial_role  Plan: 1 to add
NEW guard, create=false, no role        No changes
```

`terraform fmt -check -recursive` and `terraform validate` pass (now enforced by #35).

## Risk

Low. Two lines of guard logic, no resource addresses change, and the set of created resources is identical for every configuration that could already plan. For anyone currently blocked by this, it turns a failing plan into a working one.

No AWS credentials in my environment, so this has not been run as a real `terraform plan` against a live stack.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NvfKKjdfjNzSBTidn9Q9)_