### PR TITLE
fix: align Route53 record guards with the aws_lb data source

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -11,24 +11,18 @@ data "aws_service_discovery_http_namespace" "namespace" {
   name  = var.ecs_cluster_name
 }
 
-# ALB lookups are gated only on the listener being set, so the DNS name and
-# zone id are always exported (see outputs.tf) and can be used to create DNS
-# records (Route53, Cloudflare, etc.) outside this module.
+# Gated only on the ARN being resolvable, so the DNS name and zone id are always
+# exported (see outputs.tf) and can be used to create DNS records (Route53,
+# Cloudflare, etc.) outside this module. ARN resolution lives in locals.tf and
+# covers both the ALB and NLB paths.
 data "aws_lb" "main_alb" {
-  count = var.application_load_balancer.enabled && var.application_load_balancer.listener_arn != "" ? 1 : 0
+  count = var.application_load_balancer.enabled && local.main_lb_arn != "" ? 1 : 0
 
-  # Extract ALB ARN from listener ARN by removing the listener part
-  # From: arn:aws:elasticloadbalancing:us-east-1:556196322339:listener/app/production-alb/0477f09e7143a1db/398beeae51e94e2d
-  # To:   arn:aws:elasticloadbalancing:us-east-1:556196322339:loadbalancer/app/production-alb/0477f09e7143a1db
-  arn = replace(regex("^(.+)/[^/]+$", var.application_load_balancer.listener_arn)[0], ":listener/", ":loadbalancer/")
+  arn = local.main_lb_arn
 }
 
 data "aws_lb" "additional_albs" {
-  for_each = {
-    for idx, alb in var.additional_load_balancers : idx => alb
-    if alb.enabled && alb.listener_arn != ""
-  }
+  for_each = local.additional_lb_arns_resolved
 
-  # Extract ALB ARN from listener ARN by removing the listener part
-  arn = replace(regex("^(.+)/[^/]+$", each.value.listener_arn)[0], ":listener/", ":loadbalancer/")
+  arn = each.value
 }

--- a/locals.tf
+++ b/locals.tf
@@ -25,6 +25,47 @@ locals {
     var.network_mode != "awsvpc" || (length(var.subnet_ids) > 0 && length(var.security_group_ids) > 0)
   ) ? true : tobool("subnet_ids and security_group_ids are required when network_mode is 'awsvpc'")
 
+  # HTTP callers pass a listener ARN, from which the load balancer ARN is
+  # derived. TCP callers pass nlb_arn directly, because the module creates the
+  # listener itself and there is no caller-supplied listener ARN to derive from.
+  # regexall rather than regex: this is evaluated unconditionally, and regex
+  # raises an error when listener_arn is "".
+  listener_arn_pattern = "^(.+)/[^/]+$"
+
+  main_lb_arn_from_listener = length(regexall(local.listener_arn_pattern, var.application_load_balancer.listener_arn)) > 0 ? replace(
+    regexall(local.listener_arn_pattern, var.application_load_balancer.listener_arn)[0][0],
+    ":listener/", ":loadbalancer/"
+  ) : ""
+
+  main_lb_arn = var.application_load_balancer.protocol == "TCP" ? var.application_load_balancer.nlb_arn : local.main_lb_arn_from_listener
+
+  additional_lb_arns = {
+    for idx, alb in var.additional_load_balancers : idx => (
+      alb.protocol == "TCP" ? alb.nlb_arn : (
+        length(regexall(local.listener_arn_pattern, alb.listener_arn)) > 0 ? replace(
+          regexall(local.listener_arn_pattern, alb.listener_arn)[0][0],
+          ":listener/", ":loadbalancer/"
+        ) : ""
+      )
+    )
+  }
+
+  # Drives the aws_lb data source's for_each, so its keys and every consumer's
+  # keys stay in lockstep.
+  additional_lb_arns_resolved = {
+    for idx, alb in var.additional_load_balancers : idx => local.additional_lb_arns[idx]
+    if alb.enabled && local.additional_lb_arns[idx] != ""
+  }
+
+  # An alias record needs dns_name/zone_id from the aws_lb data source, so it can
+  # only be created where that data source exists.
+  create_main_route53_record = (
+    var.application_load_balancer.enabled &&
+    var.application_load_balancer.route_53_host_zone_id != "" &&
+    var.application_load_balancer.host != "" &&
+    local.main_lb_arn != ""
+  )
+
   # Target group naming logic with 32-char safety
   main_target_group_name = var.application_load_balancer.target_group_name != "" ? var.application_load_balancer.target_group_name : replace(
     "${substr(var.ecs_service_name, 0, 20)}-${substr(md5("${data.aws_ecs_cluster.ecs_cluster.cluster_name}-${var.ecs_service_name}"), 0, 5)}-tg",

--- a/outputs.tf
+++ b/outputs.tf
@@ -27,7 +27,7 @@ output "ssm_role_parameter_name" {
 output "route53_records" {
   description = "Route53 DNS records created"
   value = {
-    main_record = var.application_load_balancer.enabled && var.application_load_balancer.route_53_host_zone_id != "" && var.application_load_balancer.host != "" ? {
+    main_record = local.create_main_route53_record ? {
       name    = aws_route53_record.main_alb_record[0].name
       fqdn    = aws_route53_record.main_alb_record[0].fqdn
       zone_id = aws_route53_record.main_alb_record[0].zone_id
@@ -45,7 +45,7 @@ output "route53_records" {
 output "load_balancer" {
   description = "DNS details of the ALB(s) fronting the service. Use these (e.g. dns_name) to create DNS records such as Cloudflare CNAMEs outside this module."
   value = {
-    main = var.application_load_balancer.enabled && var.application_load_balancer.listener_arn != "" ? {
+    main = var.application_load_balancer.enabled && local.main_lb_arn != "" ? {
       dns_name = data.aws_lb.main_alb[0].dns_name
       zone_id  = data.aws_lb.main_alb[0].zone_id
       host     = var.application_load_balancer.host
@@ -56,7 +56,7 @@ output "load_balancer" {
         zone_id  = data.aws_lb.additional_albs[idx].zone_id
         host     = alb.host
       }
-      if alb.enabled && alb.listener_arn != ""
+      if alb.enabled && local.additional_lb_arns[idx] != ""
     }
   }
 }

--- a/resources.tf
+++ b/resources.tf
@@ -104,8 +104,8 @@ resource "aws_lb_listener_rule" "rule" {
         }
 
         stickiness {
-          enabled  = lookup(var.application_load_balancer, "stickiness", false)
-          duration = lookup(var.application_load_balancer, "stickiness_ttl", 300)
+          enabled  = var.application_load_balancer.stickiness
+          duration = var.application_load_balancer.stickiness_ttl
         }
       }
     }
@@ -165,8 +165,8 @@ resource "aws_lb_listener_rule" "rule_additional" {
         }
 
         stickiness {
-          enabled  = lookup(each.value, "stickiness", false)
-          duration = lookup(each.value, "stickiness_ttl", 300)
+          enabled  = each.value.stickiness
+          duration = each.value.stickiness_ttl
         }
       }
     }
@@ -792,7 +792,7 @@ module "ecr" {
 
 # Route 53 record for main ALB
 resource "aws_route53_record" "main_alb_record" {
-  count   = var.application_load_balancer.enabled && var.application_load_balancer.route_53_host_zone_id != "" && var.application_load_balancer.host != "" ? 1 : 0
+  count   = local.create_main_route53_record ? 1 : 0
   zone_id = var.application_load_balancer.route_53_host_zone_id
   name    = var.application_load_balancer.host
   type    = "A"
@@ -808,7 +808,7 @@ resource "aws_route53_record" "main_alb_record" {
 resource "aws_route53_record" "additional_alb_records" {
   for_each = {
     for idx, alb in var.additional_load_balancers : idx => alb
-    if alb.enabled && alb.route_53_host_zone_id != "" && alb.host != ""
+    if alb.enabled && alb.route_53_host_zone_id != "" && alb.host != "" && local.additional_lb_arns[idx] != ""
   }
 
   zone_id = each.value.route_53_host_zone_id


### PR DESCRIPTION
Fourth of a series splitting #33 into small PRs. Follows #34, #35, #36. Like #36, this fixes a bug present in released **v1.1.1**, and is independent of it.

## Problem

The Route53 record and the data source it reads are gated on different conditions.

```hcl
# resources.tf — record created when...
count = enabled && route_53_host_zone_id != "" && host != ""

# data.tf — but the data source it dereferences exists only when...
count = enabled && listener_arn != ""
```

The record's `alias` block reads `data.aws_lb.main_alb[0].dns_name`. Whenever the first condition holds and the second does not, that index does not exist and the plan fails:

```
Error: Invalid index
  on resources.tf line 501, in resource "aws_route53_record" "main_alb_record":
 501:     name = data.aws_lb.main_alb[0].dns_name
The given key does not identify an element in this collection value.
```

Two reachable configurations hit this:

1. **NLB / `protocol = "TCP"`.** The load balancer ARN arrives as `nlb_arn`, not `listener_arn` — the module creates the listener itself via `aws_lb_listener.tcp_listener`, so there is no caller-supplied listener ARN. NLB is a documented, supported mode (README line 241). Any NLB user wanting a Route53 record is blocked.
2. **Route53 fields set with no listener at all.** Same mismatch, no NLB required.

`additional_load_balancers` has the identical mismatch between `aws_route53_record.additional_alb_records` and `data.aws_lb.additional_albs`.

Notably the `load_balancer` output *does* guard correctly on `listener_arn` — so two of the three consumers were right and the record resources were not.

## Fix

Resolve the load balancer ARN once, in `locals.tf`, covering both paths:

```hcl
main_lb_arn = var.application_load_balancer.protocol == "TCP"
  ? var.application_load_balancer.nlb_arn      # NLB: given directly
  : local.main_lb_arn_from_listener            # ALB: derived from the listener
```

and give the data source, both record resources, and both outputs the same guard — `local.main_lb_arn != ""`.

`regexall` replaces `regex` because the expression is now evaluated unconditionally rather than inside a guarded resource block, and `regex` raises an error on no match instead of returning empty.

**Side effect worth knowing:** the `load_balancer` output now populates for NLBs. It previously always returned `null` for them, since it was gated on `listener_arn`.

Also folds in the four `lookup()` calls on typed objects in the stickiness blocks (`lookup(var.application_load_balancer, "stickiness", false)` → `var.application_load_balancer.stickiness`). Same file, same code paths, and the attributes are `optional(...)` with defaults so they are always present — identical values, no behaviour change.

## Verification

`terraform validate` cannot catch a count/index mismatch, so this is checked with a harness that extracts the guard expressions directly from `locals.tf` — it cannot drift from the shipped code — and asserts that no consumer indexes a data source instance its own guard does not require to exist.

| Configuration | pre-fix | post-fix |
|---|---|---|
| ALB + Route53 | safe | SAFE |
| **NLB/TCP + Route53** | **UNSAFE** | SAFE |
| **Route53, no LB ARN** | **UNSAFE** | SAFE |
| ALB, no Route53 | safe | SAFE |
| **additional: NLB + Route53** | **UNSAFE** | SAFE |
| **additional: Route53, no ARN** | **UNSAFE** | SAFE |
| additional: mixed ALB/NLB/unresolvable | — | SAFE (keys `['0','1']`, third correctly excluded) |
| LB disabled | — | SAFE |

The pre-fix column is the control: the harness reports four failures against the old guards, so it is not passing vacuously.

`fmt -check -recursive` and `validate` pass on all three roots.

## Risk

Low for existing ALB users: `local.main_lb_arn` computes the identical ARN from `listener_arn`, so the data source count, its keys, both outputs, and the record counts are all unchanged — no diff.

For NLB users the record and the `load_balancer` output start working where the plan previously failed outright, so there is no working state to regress.

No AWS credentials in my environment, so this has not been run as a real `terraform plan` against a live stack.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NvfKKjdfjNzSBTidn9Q9)_