### PR TITLE
feat: honor ecs_launch_type and match target_type to network_mode

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -25,6 +25,11 @@ locals {
     var.network_mode != "awsvpc" || (length(var.subnet_ids) > 0 && length(var.security_group_ids) > 0)
   ) ? true : tobool("subnet_ids and security_group_ids are required when network_mode is 'awsvpc'")
 
+  # awsvpc tasks get their own ENI and register with the target group by IP;
+  # bridge and host tasks share the instance network stack and register by
+  # instance id.
+  target_group_target_type = var.network_mode == "awsvpc" ? "ip" : "instance"
+
   # HTTP callers pass a listener ARN, from which the load balancer ARN is
   # derived. TCP callers pass nlb_arn directly, because the module creates the
   # listener itself and there is no caller-supplied listener ARN to derive from.

--- a/resources.tf
+++ b/resources.tf
@@ -21,7 +21,7 @@ resource "aws_alb_target_group" "target_group" {
   port                 = var.application_load_balancer.container_port
   protocol             = var.application_load_balancer.protocol
   vpc_id               = var.vpc_id
-  target_type          = "ip"
+  target_type          = local.target_group_target_type
   deregistration_delay = var.application_load_balancer.deregister_deregistration_delay
 
   dynamic "stickiness" {
@@ -58,7 +58,7 @@ resource "aws_alb_target_group" "target_group_additional" {
   port                 = each.value.container_port
   protocol             = each.value.protocol
   vpc_id               = var.vpc_id
-  target_type          = "ip"
+  target_type          = local.target_group_target_type
   deregistration_delay = each.value.deregister_deregistration_delay
 
   dynamic "stickiness" {
@@ -273,10 +273,10 @@ resource "aws_ecs_service" "ecs_service" {
   deployment_maximum_percent         = var.deployment.max_healthy_percent
 
   enable_execute_command = var.enable_execute_command
-  launch_type            = var.capacity_provider_strategy == "" ? "FARGATE" : null
+  launch_type            = var.capacity_provider_strategy == "" ? var.ecs_launch_type : null
   scheduling_strategy    = "REPLICA"
   propagate_tags         = "SERVICE"
-  platform_version       = var.ecs_launch_type == "FARGATE" ? "LATEST" : ""
+  platform_version       = var.ecs_launch_type == "FARGATE" ? "LATEST" : null
   deployment_controller {
     type = "ECS"
   }


### PR DESCRIPTION
Fifth of a series splitting #33 into small PRs. Follows #34, #35, #36, #37.

> ⚠️ **This is the first PR in the series that can cause infrastructure churn.** See *Risk* — it needs a `terraform plan` against a real stack before merging. I have no AWS credentials, so I could not run one.

## Problem

Two hardcoded values make the EC2 launch type unusable.

**1. `launch_type` ignores `var.ecs_launch_type`.**

```hcl
launch_type = var.capacity_provider_strategy == "" ? "FARGATE" : null
```

Set `ecs_launch_type = "EC2"` without a capacity provider and the task definition is registered with `requires_compatibilities = ["EC2"]` while the service is created with `launch_type = "FARGATE"`. The variable is validated to accept `"EC2"`, and the README advertises EC2 — but the value is discarded.

**2. `target_type` is hardcoded to `"ip"`.**

`ip` is correct only for `awsvpc`, where each task gets its own ENI. Tasks in `bridge` or `host` mode share the instance's network stack and must register by instance id. An EC2 service on those modes therefore cannot register with its target group — the ALB has a target group it can never fill.

These belong in one PR because they are one capability: honoring `ecs_launch_type` is what makes EC2 reachable, and `target_type` is what lets an EC2 service actually attach to a load balancer. Fixing either alone leaves EC2 + ALB broken.

Also sets `platform_version` to `null` rather than `""` for EC2, where the field does not apply.

## Changes

```hcl
launch_type = var.capacity_provider_strategy == "" ? var.ecs_launch_type : null
target_type = local.target_group_target_type    # awsvpc ? "ip" : "instance"
```

## Verification

Every combination of `network_mode` × `ecs_launch_type` × capacity provider:

| Configuration | `target_type` | `launch_type` before → after | changes? |
|---|---|---|---|
| FARGATE + awsvpc *(module default)* | `ip` | `FARGATE` → `FARGATE` | no |
| FARGATE + awsvpc + cap provider | `ip` | `null` → `null` | no |
| EC2 + awsvpc + cap provider | `ip` | `null` → `null` | no |
| EC2 + bridge/host + cap provider | **`instance`** | `null` → `null` | target_type only |
| EC2 + awsvpc, no cap provider | `ip` | `FARGATE` → **`EC2`** | launch_type only |
| EC2 + bridge/host, no cap provider | **`instance`** | `FARGATE` → **`EC2`** | both |

`terraform fmt -check -recursive` and `terraform validate` pass on all three roots.

## Risk

Neither change can affect a configuration that works today, and the two risks are disjoint:

- **`launch_type`** changes only for **EC2 without a capacity provider**. With a capacity provider it is `null` before and after — and that is how EC2 is actually used here (see `examples/gpu`, which sets `capacity_provider_strategy`). The only affected configuration is the one currently being submitted to AWS as `FARGATE` despite an EC2 task definition.
- **`target_type`** changes only for **`bridge`/`host`**, and only when a load balancer is enabled — with no load balancer there is no target group at all. Every `awsvpc` service, which is all Fargate plus the module default, still resolves to `"ip"`, byte-identical to the hardcoded value.

**The one thing to check before merging:** `target_type` is `ForceNew`. If you run an EC2 service on `bridge`/`host` **with** a load balancer, the plan will show a **target group replacement**. That configuration could never register targets, so it was already broken — but a replacement is real churn, and the listener rule is updated to point at the new target group. Please confirm with a plan against a live stack; a clean plan on any Fargate/`awsvpc` service is expected and is the common case.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NvfKKjdfjNzSBTidn9Q9)_