### PR TITLE
refactor: build container definitions with jsonencode

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -132,15 +132,33 @@ locals {
   alb_port = local.use_alb ? floor(var.application_load_balancer.container_port + 0) : 0
   sc_port  = local.use_service_connect ? floor(var.service_connect.port + 0) : 0
 
-  # Build port mappings as JSON string directly
-  port_mappings_json = local.use_alb ? "[{\"name\":\"default\",\"containerPort\":${local.alb_port},\"hostPort\":${local.alb_port},\"protocol\":\"tcp\",\"appProtocol\":\"http\"}]" : (
-    local.use_service_connect ? (
-      lookup(var.service_connect, "appProtocol", "http") == "http" ?
-      "[{\"name\":\"default\",\"containerPort\":${local.sc_port},\"hostPort\":${local.sc_port},\"protocol\":\"tcp\",\"appProtocol\":\"http\"}]" :
-      "[{\"name\":\"default\",\"containerPort\":${local.sc_port},\"hostPort\":${local.sc_port},\"protocol\":\"tcp\"}]"
-    ) : "[]"
-  )
+  # Effective container port, and whether to advertise appProtocol = http.
+  # Service Connect with appProtocol = "tcp" omits appProtocol from the mapping.
+  container_port     = local.use_alb ? local.alb_port : (local.use_service_connect ? local.sc_port : 0)
+  include_http_proto = local.use_alb || (local.use_service_connect && var.service_connect.appProtocol == "http")
 
-  # Build the complete container definition as JSON string
-  container_definitions_json = "[{\"name\":\"${var.container_name}\",\"image\":\"${var.container_image}\",\"essential\":true,\"portMappings\":${local.port_mappings_json}}]"
+  port_mappings = (local.use_alb || local.use_service_connect) ? [
+    merge(
+      {
+        name          = "default"
+        containerPort = local.container_port
+        hostPort      = local.container_port
+        protocol      = "tcp"
+      },
+      local.include_http_proto ? { appProtocol = "http" } : {}
+    )
+  ] : []
+
+  # jsonencode rather than a hand-built string, so characters that are special
+  # in JSON are escaped correctly in container_name and container_image.
+  container_definitions = [
+    {
+      name         = var.container_name
+      image        = var.container_image
+      essential    = true
+      portMappings = local.port_mappings
+    }
+  ]
+
+  container_definitions_json = jsonencode(local.container_definitions)
 }


### PR DESCRIPTION
Seventh of a series splitting #33 into small PRs. Follows #34–#39. One file, `locals.tf`.

## Problem

The container definition is assembled by string interpolation:

```hcl
container_definitions_json = "[{\"name\":\"${var.container_name}\",\"image\":\"${var.container_image}\",…}]"
```

Interpolated values are dropped in verbatim, so any character that is special in JSON corrupts the document. This is not theoretical — image tags and container names are user-supplied strings.

With `container_image = repo/i:v1"x`:

```
old  INVALID JSON   [{"name":"app","image":"repo/i:v1"x","essential":true,…
new  parses         [{"essential":true,"image":"repo/i:v1\"x","name":"app",…
```

The old output is not merely different, it is **unparseable** — the unescaped quote terminates the string early. The ECS API rejects the task definition.

A backslash is silently wrong rather than fatal. With `container_name = a\b`:

```
old  "name":"a\b"     ← invalid escape sequence, decodes to whatever follows \b
new  "name":"a\\b"    ← correctly escaped
```

## Change

Build the structure in HCL and let `jsonencode` serialize it. Escaping becomes the encoder's problem rather than something the template has to get right.

Also replaces `lookup(var.service_connect, "appProtocol", "http")` with `var.service_connect.appProtocol` — the attribute is declared `optional(string, "http")` so it is always present, and the rest of the module already accesses it directly (`resources.tf`).

## Verification

Old and new implementations were run side by side and their outputs compared as **parsed JSON**, so key ordering is not treated as a difference:

| Configuration | Result |
|---|---|
| no load balancer, no Service Connect | MATCH |
| ALB | MATCH |
| Service Connect, `appProtocol = http` | MATCH |
| Service Connect, `appProtocol = tcp` | MATCH |
| ALB takes precedence over Service Connect | MATCH |
| `container_image` containing `"` | old **fails to parse**, new correct |
| `container_name` containing `\` | old unescaped, new correct |

Every real-world configuration is byte-for-byte equivalent after parsing; the only behavioural differences are the two cases where the old output was malformed.

`terraform fmt -check -recursive` and `terraform validate` pass on the module and both example roots.

## Risk

None for existing services. The rendered JSON is semantically identical for every configuration that produced valid JSON before, and `aws_ecs_task_definition` carries `lifecycle { ignore_changes = all }`, so existing task definitions are not re-registered regardless.

This also sets up `gpu_count`, which needs `resourceRequirements` in the container definition — practical to add to a structure, awkward to splice into a string.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NvfKKjdfjNzSBTidn9Q9)_