### PR TITLE
feat: require Terraform &gt;= 1.9 and enforce the network-mode validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ the squash commit; without one the release workflow defaults to a patch bump.
 
 ## [Unreleased]
 
+### Changed
+
+- **Minimum Terraform is now `>= 1.9`**, declared in `versions.tf`. Required for
+  validation rules that reference other input variables.
+- **The network-mode validations are now enforced.** They existed as
+  `tobool(...)` expressions in unreferenced locals, so Terraform never evaluated
+  them and they never rejected anything. They are now real `validation` blocks
+  on `network_mode`:
+
+  - Fargate requires `network_mode = "awsvpc"`.
+  - `network_mode = "awsvpc"` requires non-empty `subnet_ids` and
+    `security_group_ids`.
+
+  A configuration violating either used to plan and apply; it now fails at plan.
+  Both describe configurations AWS rejects anyway, but the failure moves earlier
+  and is visible to anyone who had one latent.
+
 ### Removed
 
 - **Built-in autoscaling.** The `cpu_auto_scaling`, `memory_auto_scaling`,

--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ This module is released under the MIT License.
 
 | Name | Version |
 |------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Providers

--- a/locals.tf
+++ b/locals.tf
@@ -23,16 +23,6 @@ locals {
   has_task_role      = var.task_role_arn != "" || local.has_service_role
   has_execution_role = var.execution_role_arn != "" || local.has_service_role
 
-  # Validation: Fargate requires awsvpc network mode
-  validate_fargate_network_mode = (
-    var.ecs_launch_type != "FARGATE" || var.network_mode == "awsvpc"
-  ) ? true : tobool("Fargate launch type requires network_mode = 'awsvpc'")
-
-  # Validation: awsvpc network mode requires subnet_ids and security_group_ids
-  validate_awsvpc_network_config = (
-    var.network_mode != "awsvpc" || (length(var.subnet_ids) > 0 && length(var.security_group_ids) > 0)
-  ) ? true : tobool("subnet_ids and security_group_ids are required when network_mode is 'awsvpc'")
-
   # awsvpc tasks get their own ENI and register with the target group by IP;
   # bridge and host tasks share the instance network stack and register by
   # instance id.

--- a/variables.tf
+++ b/variables.tf
@@ -193,6 +193,16 @@ variable "network_mode" {
     condition     = contains(["awsvpc", "bridge", "host", "none"], var.network_mode)
     error_message = "Valid values for network_mode are: awsvpc, bridge, host, none."
   }
+
+  validation {
+    condition     = var.ecs_launch_type != "FARGATE" || var.network_mode == "awsvpc"
+    error_message = "Fargate requires network_mode = \"awsvpc\"."
+  }
+
+  validation {
+    condition     = var.network_mode != "awsvpc" || (length(var.subnet_ids) > 0 && length(var.security_group_ids) > 0)
+    error_message = "network_mode = \"awsvpc\" requires subnet_ids and security_group_ids."
+  }
 }
 variable "deployment" {
   description = "Deployment configuration for the ECS service"

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,8 @@
 terraform {
+  # 1.9 introduced validation rules that can reference other input variables,
+  # which the network_mode validations rely on.
+  required_version = ">= 1.9"
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
Continues the series splitting #33 into small PRs (#34–#40, #42–#44). 4 files, +31/−10.

## Problem

Two validations existed but never ran:

```hcl
validate_fargate_network_mode = (
  var.ecs_launch_type != "FARGATE" || var.network_mode == "awsvpc"
) ? true : tobool("Fargate launch type requires network_mode = 'awsvpc'")

validate_awsvpc_network_config = (
  var.network_mode != "awsvpc" || (length(var.subnet_ids) > 0 && length(var.security_group_ids) > 0)
) ? true : tobool("subnet_ids and security_group_ids are required when network_mode is 'awsvpc'")
```

The `tobool("...")` trick is a real pattern — it forces an error with a custom message — but it only fires if the local is evaluated, and Terraform evaluates a local lazily, only when something reads it. Nothing referenced either one. I checked: no `.tf` file outside `locals.tf` mentions either name.

So a Fargate service with `network_mode = "bridge"`, or an `awsvpc` service with no subnets, planned and applied cleanly and then failed at the ECS API with a less obvious message.

## Change

Real `validation` blocks on `network_mode`:

- Fargate requires `network_mode = "awsvpc"`
- `network_mode = "awsvpc"` requires non-empty `subnet_ids` and `security_group_ids`

Both reference *other* input variables, which needs Terraform 1.9 — hence `required_version = ">= 1.9"` in `versions.tf`. The dead locals are removed.

## Verification

`terraform validate` cannot test this: it does not load variable values, so validation rules never fire under it. `terraform plan` against the real module hits the AWS provider first and fails on credentials before reaching anything useful.

So the validation blocks were extracted verbatim from `variables.tf` into a provider-free root — no drift possible — and exercised with `terraform plan`, using the exit code rather than output matching:

| Configuration | Expected | Result |
|---|---|---|
| FARGATE + awsvpc + subnets/SGs | accepted | accepted |
| EC2 + awsvpc + subnets/SGs | accepted | accepted |
| EC2 + bridge, no subnets | accepted | accepted |
| EC2 + host, no subnets | accepted | accepted |
| FARGATE + bridge | rejected | rejected — *Fargate requires network_mode = "awsvpc".* |
| awsvpc, no subnets | rejected | rejected — *requires subnet_ids and security_group_ids.* |
| awsvpc, no security groups | rejected | rejected — *requires subnet_ids and security_group_ids.* |
| module defaults (awsvpc, both empty) | rejected | rejected — *requires subnet_ids and security_group_ids.* |

That last row is the module's own defaults: `network_mode` defaults to `awsvpc` and both lists default to `[]`, so the module now requires the caller to supply networking rather than failing later at the API.

Every example module block already passes `subnet_ids` and `security_group_ids` — checked by parsing each `module` block — so no example starts failing. `fmt -check -recursive` and `validate` pass on all three roots.

## Risk

Two groups are affected, and both are worth stating plainly:

1. **Consumers on Terraform < 1.9** cannot use the module after this. `required_version` blocks them at init.
2. **Anyone with a latent invalid configuration** — Fargate on a non-`awsvpc` network mode, or `awsvpc` without subnets — starts failing at plan where they previously did not. Such a configuration cannot have been working (AWS rejects it), but the failure surfaces earlier and in a new place.

Staying on 2.x per your call, so this merges as `feat:` → v2.3.0. Both of the above would conventionally warrant a major; flagging so the choice is deliberate rather than accidental.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NvfKKjdfjNzSBTidn9Q9)_