### PR TITLE
docs: correct inaccurate claims in README, CHANGELOG and CONTRIBUTING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ Releases are cut automatically from conventional-commit messages on merge to
 `main`. A breaking change requires `feat!:` or a `BREAKING CHANGE:` footer in
 the squash commit; without one the release workflow defaults to a patch bump.
 
-## [Unreleased]
+## [3.0.0]
 
-### Changed
+### Breaking changes
 
 - **The IAM role interface is now two symmetric objects, `task_role` and
   `execution_role`**, each accepting `create`, `arn`, `name`, `inline_policy`
@@ -53,6 +53,9 @@ the squash commit; without one the release workflow defaults to a patch bump.
   `execution_role_name`. The ARN outputs report the role in effect whether it
   was created here or supplied.
 
+## [2.4.0]
+
+### Changed
 
 - **`ecr.mutability` now defaults to `IMMUTABLE`** (was `MUTABLE`). Immutable
   tags stop a build from silently replacing an image another deployment is
@@ -72,9 +75,13 @@ the squash commit; without one the release workflow defaults to a patch bump.
   Set `ecr = { mutability = "MUTABLE" }` to keep the previous behaviour. A
   validation now rejects any value other than `MUTABLE` or `IMMUTABLE`.
 
+## [2.3.0]
+
+### Changed
 
 - **Minimum Terraform is now `>= 1.9`**, declared in `versions.tf`. Required for
   validation rules that reference other input variables.
+
 - **The network-mode validations are now enforced.** They existed as
   `tobool(...)` expressions in unreferenced locals, so Terraform never evaluated
   them and they never rejected anything. They are now real `validation` blocks
@@ -87,6 +94,8 @@ the squash commit; without one the release workflow defaults to a patch bump.
   A configuration violating either used to plan and apply; it now fails at plan.
   Both describe configurations AWS rejects anyway, but the failure moves earlier
   and is visible to anyone who had one latent.
+
+## [2.2.0]
 
 ### Removed
 
@@ -107,6 +116,20 @@ the squash commit; without one the release workflow defaults to a patch bump.
   upgrading.
 
   `SQS_AUTOSCALING_MIGRATION.md` and the four autoscaling examples are removed.
+
+## [2.1.1]
+
+### Documentation
+
+- Added `CHANGELOG.md`, `CONTRIBUTING.md` and `.github/CODEOWNERS`.
+- README corrected: the module was described as Fargate-only despite EC2
+  support since v1.2.0; usage examples carried a placeholder `version = "xxx"`;
+  HCL blocks were fenced as `python`; the resources list omitted the ECR
+  repository and IAM role. Added a section documenting that the initial task
+  definition is write-once.
+- Rewrote variable descriptions that carried no information
+  (`application_load_balancer`, `capacity_provider_strategy`, `desired_count`,
+  `service_connect`).
 
 ## [2.1.0]
 
@@ -196,7 +219,7 @@ module default — resolves to `ip` and is unaffected. An EC2 service on
 
 ## Notes on earlier releases
 
-- Cloudflare DNS management was removed in v1.1.0. If an earlier version managed
+- Cloudflare DNS management was removed in v1.0.0. If an earlier version managed
   a `cloudflare_record` for you, remove it from the module's state
   (`terraform state rm ...`) and manage the record in your own configuration
   using the `load_balancer` output.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,9 @@
 
 ## Requirements
 
-Terraform and the AWS provider `>= 5.0`. No AWS credentials are needed for
-`fmt` or `validate`.
+Terraform `>= 1.9` (declared in `versions.tf`; required for validation rules
+that reference other input variables) and the AWS provider `>= 5.0`. No AWS
+credentials are needed for `fmt` or `validate`.
 
 ## Before opening a pull request
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ actual change — update them in the pipeline that registers the task definition
 | `ecs_task_cpu`, `ecs_task_memory` | CI task definition |
 | `container_name`, `container_image` | CI task definition |
 | `network_mode` | CI task definition (also selects target group `target_type`) |
-| `task_role_arn`, `execution_role_arn` | CI, via the SSM parameters below |
+| `task_role`, `execution_role` | CI, via the SSM parameters below |
 
 Inputs on the *service* — load balancer wiring, Service Connect, placement,
 deployment settings — reconcile normally. The exception is `desired_count`,
@@ -58,7 +58,7 @@ which is also ignored so an external autoscaler can own the running count.
 
 module "demo_ecs_service" {
   source  = "delivops/ecs-service/aws"
-  version = "~> 2.1"
+  version = "~> 3.0"
 
   ecs_cluster_name   = var.cluster_name
   ecs_service_name   = "demo"
@@ -77,7 +77,7 @@ module "demo_ecs_service" {
 
 module "alb_ecs_service" {
   source  = "delivops/ecs-service/aws"
-  version = "~> 2.1"
+  version = "~> 3.0"
   ecs_cluster_name   = var.cluster_name
   ecs_service_name   = "alb"
   vpc_id             = var.vpc_id
@@ -103,7 +103,7 @@ module "alb_ecs_service" {
 
 module "alb_ecs_service_with_route53" {
   source  = "delivops/ecs-service/aws"
-  version = "~> 2.1"
+  version = "~> 3.0"
   ecs_cluster_name   = var.cluster_name
   ecs_service_name   = "route53-demo"
   vpc_id             = var.vpc_id
@@ -130,7 +130,7 @@ module "alb_ecs_service_with_route53" {
 
 module "alb_ecs_service" {
   source  = "delivops/ecs-service/aws"
-  version = "~> 2.1"
+  version = "~> 3.0"
   ecs_cluster_name   = var.cluster_name
   ecs_service_name   = "cloudflare-demo"
   vpc_id             = var.vpc_id
@@ -266,11 +266,11 @@ only seeds the count at service creation.
 
 ## Notes
 
-- The module uses ARM64 architecture by default
-- The task definition is configured with 1024 CPU units and 2048MB memory
-- Default container image is nginx:stable
-- The module ignores changes to task definition and container definitions to support external deployments
-- If you work with load balancer from type NLB, you should create it yourself (not with terraform), and also to put the target_group_protocol and health_check_protocol to "TCP".
+- Task CPU and memory default to 256 units / 512 MiB, configurable via `ecs_task_cpu` and `ecs_task_memory`
+- The default container image is `nginx:latest`, overridable via `container_image`
+- The module sets no `runtime_platform`, so the task definition uses the ECS default (Linux/X86_64). Set the architecture in the CI-managed task definition if you need ARM64.
+- The module ignores changes to the task definition to support external (CI-managed) deployments
+- An NLB must be created outside this module. Pass its ARN as `nlb_arn`, set `protocol = "TCP"` and `health_check_protocol = "TCP"`; the module creates the listener and can still manage the Route53 alias record for it.
 
 ## License
 


### PR DESCRIPTION
Audit of every documented claim against `main` at v3.0.0. Eight inaccuracies found and fixed — three of them introduced by this documentation series, five pre-existing.

## README — Notes section contradicted the module

All three predate this work (`de946b6`) and were never true of the current code:

| Claim | Reality |
|---|---|
| "The module uses ARM64 architecture by default" | No `runtime_platform`, `cpu_architecture` or `arm64` appears anywhere in the module. The task definition uses the ECS default, Linux/X86_64. |
| "configured with 1024 CPU units and 2048MB memory" | `ecs_task_cpu` defaults to `256`, `ecs_task_memory` to `512` |
| "Default container image is nginx:stable" | `nginx:latest` |

Someone following the ARM64 claim would have built ARM images for an X86_64 task definition.

The NLB note also now says how to configure one — `nlb_arn` plus `protocol = "TCP"` — since the module does create the listener itself.

## README — stale references

- The write-once table listed `task_role_arn` and `execution_role_arn` as **inputs**. #47 replaced them with the `task_role` / `execution_role` objects; those names now exist only as outputs.
- Usage examples pinned `version = "~> 2.1"`, which excludes v3.0.0 entirely — anyone copying an example would silently get the pre-v3 role interface.

## CHANGELOG — four shipped releases filed as unreleased

`[Unreleased]` still held everything from the last four merges. Split into the versions they actually shipped as:

| Was | Now |
|---|---|
| `[Unreleased]` role redesign | **3.0.0** |
| `[Unreleased]` ECR immutability | **2.4.0** |
| `[Unreleased]` TF 1.9 + validations | **2.3.0** |
| `[Unreleased]` autoscaling removal | **2.2.0** |
| *(absent)* | **2.1.1** — the documentation release |

Verified programmatically rather than by eye — the documented versions and the `v*` git tags from v1.1.2 onward now match exactly, with nothing tagged-but-undocumented or documented-but-untagged.

Also: the Cloudflare removal was attributed to v1.1.0. `git tag --contains` puts that commit first in **v1.0.0**.

## CONTRIBUTING — conflated two version requirements

> Terraform and the AWS provider `>= 5.0`

Terraform is `>= 1.9` (`versions.tf`, since #45); `>= 5.0` is the AWS provider. As written it read as though Terraform 5 were required.

## Verification

- Every variable and output named in the README prose resolves to a real one, checked against `variables.tf` and `outputs.tf`
- Documented defaults compared directly against the code: `256`, `512`, `nginx:latest`, no `runtime_platform` — all now agree
- CHANGELOG versions cross-checked against git tags by set comparison
- Version pins match the latest tag
- The generated `terraform-docs` tables were already in sync: `task_role` and `execution_role` present, no trace of the removed `role`, `initial_role` or `service_role_*`
- `fmt -check -recursive` and `validate` pass on all three roots

## Risk

None. Documentation only, no `.tf` changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NvfKKjdfjNzSBTidn9Q9)_