### PR TITLE
docs: add CLAUDE.md

### DIFF
--- a/.github/workflows/git-tag.yaml
+++ b/.github/workflows/git-tag.yaml
@@ -5,6 +5,7 @@ on:
       - main
     paths-ignore:
       - 'README.md'
+      - 'CLAUDE.md'
       - '.github/**'
       - 'examples/**'         
 permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,160 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+A published Terraform module (`delivops/ecs-service/aws`) that provisions an ECS
+service. There is no application code, no test suite, and no way to run anything
+against AWS from this repo — verification is `fmt`, `validate`, and reasoning.
+
+## Commands
+
+Three **independent Terraform roots**. A change to the module's variables can
+break an example without breaking the module, so all three must be checked. CI
+runs exactly these:
+
+```bash
+terraform fmt -check -recursive          # whole repo
+
+terraform init -backend=false && terraform validate                      # module
+cd examples     && terraform init -backend=false && terraform validate    # examples
+cd examples/gpu && terraform init -backend=false && terraform validate    # separate root
+```
+
+CI pins Terraform 1.9.8; `versions.tf` requires `>= 1.9`.
+
+## Verification without AWS
+
+There are no credentials here, so `terraform plan` against the real module fails
+on the AWS provider before reaching anything useful, and `terraform validate`
+does **not** load variable values — variable `validation` blocks never fire under
+it. Neither proves much on its own.
+
+What works: build a **provider-free root** in a scratch directory that extracts
+the expressions under test *verbatim from the shipped files*, then drive it with
+`terraform plan` (exit code) or `terraform apply` + `terraform output -json`
+(values). Extracting rather than retyping means the harness cannot drift from the
+code. When testing a fix, run the harness against the **old** expression too — a
+harness that passes both ways proves nothing.
+
+`null_resource` is useful as a stand-in for a not-yet-created resource: it is a
+legacy SDKv2 provider, so its computed attributes are *unrefined* unknowns at
+plan time, matching `aws_iam_role` and most of the AWS provider. `terraform_data`
+is not equivalent — its unknowns carry a not-null refinement, so `!= null`
+collapses to a known `true` and bugs of that class do not reproduce.
+
+## Architecture
+
+### The task definition is write-once
+
+`aws_ecs_task_definition` carries `lifecycle { ignore_changes = all }`, and the
+service ignores `task_definition`. The module registers one revision to bootstrap
+the service and then never touches it again — the running revision is owned by
+the CI pipeline (`delivops/ecs-deploy-action`).
+
+Consequence: `ecs_task_cpu`, `ecs_task_memory`, `container_name`,
+`container_image` and `network_mode` **only affect the first revision**. Changing
+them on an existing service yields a clean plan and no change. Anything added to
+the container definition inherits this, so a new task-definition input is close
+to inert for existing services and needs saying so in its description.
+
+`desired_count` is likewise in the service's `ignore_changes`, so an external
+autoscaler owns the running count. This module manages no autoscaling.
+
+### SSM parameters are the contract with CI
+
+`ssm.tf` publishes the role ARNs at predictable paths for the deploy pipeline to
+read:
+
+```
+/ecs/<cluster>/<service>/task-role
+/ecs/<cluster>/<service>/execution-role
+```
+
+These are a **public interface**, not an implementation detail. Renaming or
+removing one destroys the parameter on apply and breaks deploys the moment the
+pipeline next runs. Tags are deliberately not published — the service is tagged
+and `propagate_tags = "SERVICE"` carries them to tasks.
+
+### Task role vs execution role
+
+`task_role` and `execution_role` are symmetric objects (`create`, `arn`, `name`,
+`inline_policy`, `attach_policies`); each is created here, supplied by ARN, or
+absent, and `create`/`arn` are mutually exclusive. They default differently on
+purpose: the task role starts empty because only the application knows what it
+needs, while a created execution role gets `AmazonECSTaskExecutionRolePolicy`
+because that part is identical everywhere. `AmazonECSTaskExecutionRolePolicy`
+does **not** cover secrets — `ssm:GetParameters` / `secretsmanager:GetSecretValue`
+must be added via `execution_role.inline_policy`.
+
+## Two invariants that have each caused a released bug
+
+### `count` and `for_each` must derive from configuration
+
+Deriving a `count` from a resource attribute — including `arn != null` — makes
+the count unknown at plan time and Terraform refuses to plan
+(`Invalid count argument`). This is unescapable from a clean state: the plan
+fails, so the resource is never created, so the attribute stays unknown. It
+shipped in v1.1.1 and made `role.create = true` unusable.
+
+Every `count`/`for_each` in the module currently derives from `var.*`. Keep it
+that way. Where a "does this exist" boolean is needed, compute it from inputs
+(`local.has_task_role`) rather than testing the resolved ARN.
+
+### A guard and everything that dereferences it must match
+
+`data.aws_lb` instances are dereferenced from four places: both
+`aws_route53_record` resources and both DNS-related outputs. When those guards
+drifted apart, configurations that satisfied one but not the other failed with
+`Invalid index` (v1.1.3 — the NLB path, where the ARN arrives as `nlb_arn`
+because the module creates the listener itself, and any config setting the
+Route53 fields without a listener).
+
+`locals.tf` now resolves the ARN once (`main_lb_arn`, `additional_lb_arns`,
+`additional_lb_arns_resolved`, `create_main_route53_record`) and every consumer
+shares it. Adding a consumer means using those locals, not writing a new guard.
+`terraform validate` cannot catch this class of bug.
+
+## Releases
+
+Merging to `main` cuts a tag automatically from the **squash-commit message**
+(`mathieudutour/github-tag-action`).
+
+- `fix:` / `refactor:` / `docs:` / `chore:` → patch
+- `feat:` → minor
+- `feat!:` or a `BREAKING CHANGE:` footer → major
+
+**The default is patch.** A breaking change merged without `!` or the footer
+ships as a patch and consumers on `~>` pick it up automatically. GitHub pre-fills
+the squash subject from the PR title, so the PR title must carry `feat!:` — put
+the footer in the commit body as well.
+
+Changes confined to `README.md`, `.github/**` or `examples/**` cut no release
+(`paths-ignore` in `git-tag.yaml`). A root `CHANGELOG.md` change **does**.
+
+## Docs
+
+`terraform-docs` regenerates the input/output tables between the `BEGIN_TF_DOCS`
+markers in `README.md` and **pushes a commit back to the PR branch**. Edit
+variable and output `description` fields, not the tables; prose outside the
+markers is hand-maintained.
+
+That bot commit becomes the PR head, and workflow runs triggered by it land in
+`action_required` rather than executing — so the final head of a PR that changes
+the module's public surface carries no validated result. Pre-existing, and worth
+knowing before concluding a PR is green.
+
+## Conventions
+
+- Comments explain non-obvious constraints, not narration. No comments recording
+  what the code used to do or why a change was made — that belongs in the commit
+  message. No comments describing something's absence.
+- Use typed attribute access (`var.service_connect.appProtocol`), not `lookup()`,
+  on the typed object variables.
+- Build JSON with `jsonencode` over an HCL structure. Hand-built JSON strings
+  silently corrupt on any value containing a quote or backslash.
+- The ECR repository comes from `terraform-aws-modules/ecr` v2.3.0. Check that
+  module's own variable defaults before exposing a passthrough — several already
+  match what an existing repository has, and passing a literal where it expects
+  `null` can add a `ForceNew` block that proposes a replacement.


### PR DESCRIPTION
Guidance for Claude Code sessions working in this repository. Independent of #48 — different file, no overlap.

## What it covers

Deliberately limited to things that are **not discoverable from a single file**, or that have already caused a bug here. It does not restate the file layout or generic Terraform practice.

- **No tests, no AWS access.** Verification is `fmt`, `validate`, and provider-free harnesses. Includes the technique used throughout this series: extract the expressions under test *verbatim* from the shipped files so the harness cannot drift, and run it against the **old** expression too — a harness that passes both ways proves nothing. Also records that `null_resource` reproduces unrefined-unknown behaviour (like `aws_iam_role`) while `terraform_data` does not, which is why one repro fails and the other silently passes.

- **The write-once task definition.** `ignore_changes = all` means `ecs_task_cpu`, `container_image`, `network_mode` and friends only affect the first revision. Anything added to the container definition inherits this. Not visible without reading `resources.tf` and the variable descriptions together.

- **SSM parameters are a public interface**, not an implementation detail — renaming one destroys it on apply and breaks deploys.

- **Two invariants, each behind a released bug.** `count`/`for_each` must derive from configuration, never a resource attribute (v1.1.2, `Invalid count argument`, unescapable from a clean state). And a data-source guard must match every dereference of it — `locals.tf` now resolves the LB ARN once and four consumers share it (v1.1.3, `Invalid index`). `terraform validate` catches neither.

- **Release mechanics.** Default bump is patch; GitHub pre-fills the squash subject from the PR title, so a breaking change needs `feat!:` in the title *and* the footer in the body. This is the trap that would have shipped #39 as v1.2.1.

- **The terraform-docs bot** pushes a commit back to PR branches; runs triggered by it land in `action_required`, so the final head of a PR touching the public surface carries no validated result. Worth knowing before calling a PR green.

- **Conventions** established across this series: comments explain constraints rather than narrating history, typed attribute access over `lookup()`, `jsonencode` over hand-built JSON strings, and checking the ECR submodule's own defaults before exposing a passthrough.

## Also in this PR

`CLAUDE.md` added to `git-tag.yaml`'s `paths-ignore`, alongside `README.md` — editing agent guidance should not cut a release. Without this, every touch of the file publishes a new patch version to the registry.

Worth considering the same for `CONTRIBUTING.md` and `CHANGELOG.md`, which have the same property; left out here since a CHANGELOG edit usually accompanies a real change.

## Verification

Every factual claim was checked against the code, not written from memory:

| Claim | Verified |
|---|---|
| CI pins Terraform 1.9.8 | `validate.yaml` |
| `required_version = ">= 1.9"` | `versions.tf` |
| ECR submodule v2.3.0 | `resources.tf` |
| `paths-ignore` contents | `git-tag.yaml` |
| SSM paths `/task-role`, `/execution-role` | `ssm.tf` |
| `ignore_changes = all` on the task definition | `resources.tf:264` |
| `desired_count` in the service's `ignore_changes` | `resources.tf:397` |
| zero `lookup()` calls remain | `git grep` |
| zero autoscaling resources remain | `git grep` |
| four `data.aws_lb` dereference sites | `git grep` |

## Risk

None. Markdown plus one line of workflow configuration.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4NvfKKjdfjNzSBTidn9Q9)_